### PR TITLE
chore: disable statsig telemetry and sentry error reporting by default

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "env": {
+    "DISABLE_TELEMETRY": "1",
+    "DISABLE_ERROR_REPORTING": "1"
+  },
   "permissions": {
     "allow": [
       "WebFetch(domain:daisyui.com)",


### PR DESCRIPTION
## Description
Makes usage data collection (Statsig) and error reporting (Sentry) OPT-IN rather than OPT-OUT. 

Per their [data usage policy](https://docs.anthropic.com/en/docs/claude-code/data-usage#telemetry-services), these telemetry services are Default off for vertex and bedrock apis, but Default on for anthropic api which most template users will be on. In light of recent changes to anthropic's data retention policy and [OpenAI's purchase of Statsig](https://www.bloomberg.com/news/articles/2025-09-02/openai-to-buy-product-testing-startup-statsig-for-1-1-billion), this change makes the template more friendly to privacy conscious users. 

## Changes
Set DISABLE_TELEMETRY and DISABLE_ERROR_REPORTING `env` in .claude/settings.json per the [ant reference](https://docs.anthropic.com/en/docs/claude-code/settings#environment-variables)

## Testing
Minimal. Verified the env changes vs `main` from claude code bash
<img width="957" height="183" alt="image" src="https://github.com/user-attachments/assets/3160316f-1c65-4e27-9b99-91ad0e849f5b" />
<img width="747" height="242" alt="image" src="https://github.com/user-attachments/assets/4ab54f8b-ed29-4802-be83-ba4f08e600f1" />

Could not think of an easy way to confirm ant is respecting the settings.

## Notes
Small change, so didn't open an issue first. This is my first contribution and I wasn't sure what the guidelines were- would greatly appreciate any feedback or instructions! 