### PR TITLE
[WIP] Feat/commit reminder hook (#7)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,7 +22,7 @@
   },
   "enabledMcpjsonServers": ["playwright"],
   "enableAllProjectMcpServers": true,
-    "hooks": {
+  "hooks": {
     "PostToolUse": [
       {
         "matcher": "TodoWrite",


### PR DESCRIPTION
## Description
First pass at commit reminder hook as discussed in #123. 

## Current Status
**Draft - trying to figure out how to test**
Current implementation uses hook on the PostToolUse event on "TodoWrite" that check if there are uncommitted changes and reminds claude to look at CLAUDE.md. This seemed nicer for intermediate checkpointing but on reflection probably triggers more often than it should.

## Progress
- [x] Draft hook, debugged (claude does not see stdout)
- [x] Test: terminal transcript shows `>TodoWrite operation feedback` if there are uncommitted changes<img width="1460" height="309" alt="image" src="https://github.com/user-attachments/assets/2ed2250e-3586-4702-bd2e-3b95437781c2" />
- [x] Test: does not if no uncommitted changes <img width="848" height="959" alt="image" src="https://github.com/user-attachments/assets/fdcfaf02-fa55-4410-aef4-af129185171b" />
- [x] Test: asked claude about its developer experience (reports liking it, except when there are uncommitted changes it didn't make already in the repo which trigger the reminder out of the gate, screenshots below). Obviously this is dumb, it was just the easiest thing. 
- [ ] Test: ??? effect on implementing new projects?
- [ ] Implement and test an alternative hook event (maybe `UserTurnSubmit`

## Testing screenshots
Claude (Opus) dislikes when there are already uncommitted changes (reproduced 2x)
<img width="1432" height="628" alt="image" src="https://github.com/user-attachments/assets/ef8d4691-d120-4ee7-b299-abbe715ed3e7" />
Likes it when no changes -> no reminder for the initial TodoWrite (reproduced 5x ish)
<img width="848" height="959" alt="image" src="https://github.com/user-attachments/assets/953337c5-2bcc-4597-b2ee-ad853fb2d639" />



