### PR TITLE
users: +getCurrentUserOrNull, +getCurrentUserOrCrash

### DIFF
--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,4 +1,33 @@
-import { mutation, query } from "./_generated/server";
+import { mutation, query, QueryCtx, MutationCtx } from "./_generated/server";
+import { ConvexError } from "convex/values";
+
+export async function getCurrentUserOrNull(ctx: QueryCtx | MutationCtx) {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) {
+    return null;
+  }
+
+  const user = await ctx.db
+    .query("users")
+    .withIndex("by_clerkId", (q) => q.eq("clerkId", identity.subject))
+    .unique();
+
+  if (!user) {
+    throw new ConvexError(
+      "Bug: User is authenticated with convex but is missing a record in the DB",
+    );
+  }
+
+  return user;
+}
+
+export async function getCurrentUserOrCrash(ctx: QueryCtx | MutationCtx) {
+  const user = await getCurrentUserOrNull(ctx);
+
+  if (!user) {
+    throw new ConvexError("Not authenticated");
+  }
+}
 
 export const ensureUser = mutation({
   args: {},


### PR DESCRIPTION
Other backend functions will often want the current user. Adding these functions to avoid duplicating this (security relevant) code